### PR TITLE
Add issue templates

### DIFF
--- a/ISSUE_TEMPLATE/ISSUE_TEMPLATE/accessibility.md
+++ b/ISSUE_TEMPLATE/ISSUE_TEMPLATE/accessibility.md
@@ -1,0 +1,38 @@
+---
+name: Accessibility
+about: Report an accessibility issue
+title: ''
+labels: 'accessibility-awaiting-triage'
+assignees: ''
+
+---
+### Steps to recreate
+
+
+### URL
+
+
+### Issues
+
+
+### Severity
+
+
+### WCAG Conformance level (A, AA, AAA)
+
+
+### User impact
+
+
+### Recommended fix
+
+
+### Acceptance criteria
+- [ ] I can successfully use this feature with Voice Over in Safari.
+- [ ] I have checked this feature using one of the following browser extensions and confirmed that it does not add any level A or level AA issues:
+    * axe dev tools
+    * Lighthouse
+    * Wave
+- [ ] ...
+
+### Notes

--- a/ISSUE_TEMPLATE/ISSUE_TEMPLATE/accessibility_audit.md
+++ b/ISSUE_TEMPLATE/ISSUE_TEMPLATE/accessibility_audit.md
@@ -1,0 +1,11 @@
+---
+name: Accessibility audit
+about: Evaluate part of the project for accessibility
+title: Audit [Which part of the project?] for accessibility
+labels: ["accessibility-general", "investigate"]
+assignees: ''
+
+---
+
+- [ ] Use the [accessibility audit procedure](https://github.com/pulibrary/dacs_handbook/blob/main/Accessibility/audit_procedure.md) to audit [some part of this project]
+- [ ] Use the accessibility issue template to create github issues for any issues that you encounter.

--- a/ISSUE_TEMPLATE/ISSUE_TEMPLATE/bug_report.md
+++ b/ISSUE_TEMPLATE/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: 'bug'
+assignees: ''
+
+---
+
+### Expected behavior
+A clear and concise description of what you expected to happen.
+
+### Actual behavior
+Include screenshots, or links and browser version if relevant
+
+### Steps to replicate
+
+### Impact of this bug
+E.g. "I can't work until this is fixed" or "I have a workaround"
+
+### Honeybadger link and code snippet, if applicable
+
+```
+```
+
+### Implementation notes, if any
+

--- a/ISSUE_TEMPLATE/ISSUE_TEMPLATE/dependency_upgrade.md
+++ b/ISSUE_TEMPLATE/ISSUE_TEMPLATE/dependency_upgrade.md
@@ -1,0 +1,17 @@
+---
+name: Dependency upgrade
+about: Upgrading the version of a system dependency
+title: 'Upgrade to [INSERT DEPENDENCY HERE] [INSERT VERSION NUMBER HERE]'
+labels: maintenance
+assignees: ''
+
+---
+
+- [ ] Add the new version to CircleCI
+- [ ] Add the new version to .tool-versions
+- [ ] Fix any failing tests or dependency issues caused by upgrade
+- [ ] Provision staging box to use the new version
+- [ ] Deploy code that works with the new version to staging
+- [ ] Manually test on staging box with the new version
+- [ ] Provision new boxes or use [this process to upgrade and deploy in place](https://docs.google.com/document/d/1qedt3nKl9nlSmYepT5DPYVcfDB9xvE81Qllmw_cYvf0/edit)
+- [ ] Update this issue template with anything we need to keep in mind for the next upgrade

--- a/ISSUE_TEMPLATE/ISSUE_TEMPLATE/feature_request.md
+++ b/ISSUE_TEMPLATE/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,24 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: 'feature'
+assignees: ''
+
+---
+
+### User story
+
+### Acceptance criteria
+
+- [ ] I can successfully use this feature with Voice Over in Safari.
+- [ ] I have checked this feature using one of the following browser extensions and confirmed that it does not add any level A or level AA issues:
+    * axe dev tools
+    * Lighthouse
+    * Wave
+- [ ] ...
+
+### Concrete example
+
+### Implementation notes, if any
+

--- a/ISSUE_TEMPLATE/ISSUE_TEMPLATE/maintenance-task.md
+++ b/ISSUE_TEMPLATE/ISSUE_TEMPLATE/maintenance-task.md
@@ -1,0 +1,29 @@
+---
+name: Maintenance task
+about: Document some maintenance that needs to be done
+title: ''
+labels: maintenance
+assignees: ''
+
+---
+### What maintenance needs to be done?
+
+### Level of urgency
+- [ ] High
+- [ ] Moderate
+- [ ] Low
+
+### EOL upgrade
+- [ ] EOL Date MM/DD/YYYY
+
+### Why is this maintenance needed?
+- A clear description of why this is needed.
+
+### Acceptance criteria
+ - [ ]
+ - [ ]
+ - [ ]
+
+### Implementation notes, if any
+
+

--- a/ISSUE_TEMPLATE/ISSUE_TEMPLATE/ui-change.md
+++ b/ISSUE_TEMPLATE/ISSUE_TEMPLATE/ui-change.md
@@ -1,0 +1,24 @@
+---
+name: UI change
+about: A change to the display
+title: ''
+labels: user experience
+assignees: ''
+
+---
+
+### Current display
+
+
+### Desired display
+
+### Acceptance criteria
+
+- [ ] I can successfully use this feature with Voice Over in Safari.
+- [ ] I have checked this feature using one of the following browser extensions and confirmed that it does not add any level A or level AA issues:
+    * axe dev tools
+    * Lighthouse
+    * Wave
+- [ ] ...
+
+### Notes


### PR DESCRIPTION
These templates are based on the [templates in the Orangelight repository](https://github.com/pulibrary/orangelight/tree/d7ccd85af10a8a010801afde74fed5c58a54d7e0/.github/ISSUE_TEMPLATE)

Connected to pulibrary/dacs_handbook#170